### PR TITLE
ci: fix GitHub Workflow output method

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Get npm cache directory
         id: npm-cache
         run: |
-          echo "::set-output name=dir::$(npm config get cache)"
+          echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
       - name: Check npm cache
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
fix output

ref https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/